### PR TITLE
In order to use ofbx::IScene ptr's with standard c++ lifetime constru…

### DIFF
--- a/src/ofbx.h
+++ b/src/ofbx.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 
 namespace ofbx
 {
@@ -713,7 +714,7 @@ struct IScene
 	virtual float getSceneFrameRate() const = 0;
 	virtual const GlobalSettings* getGlobalSettings() const = 0;
 
-public:
+protected:
 	virtual ~IScene() {}
 };
 
@@ -725,3 +726,16 @@ i64 secondsToFbxTime(double value);
 
 
 } // namespace ofbx
+
+template <> struct ::std::default_delete<ofbx::IScene>
+{
+	default_delete() = default;
+	template <class U> constexpr default_delete(default_delete<U>) noexcept {}
+	void operator()(ofbx::IScene* scene) const noexcept
+	{
+		if (scene)
+		{
+			scene->destroy();
+		}
+	}
+};

--- a/src/ofbx.h
+++ b/src/ofbx.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 
 namespace ofbx
 {
@@ -727,6 +726,9 @@ i64 secondsToFbxTime(double value);
 
 } // namespace ofbx
 
+#ifdef OFBX_DEFAULT_DELETER
+#include <memory>
+
 template <> struct ::std::default_delete<ofbx::IScene>
 {
 	default_delete() = default;
@@ -739,3 +741,4 @@ template <> struct ::std::default_delete<ofbx::IScene>
 		}
 	}
 };
+#endif

--- a/src/ofbx.h
+++ b/src/ofbx.h
@@ -713,7 +713,7 @@ struct IScene
 	virtual float getSceneFrameRate() const = 0;
 	virtual const GlobalSettings* getGlobalSettings() const = 0;
 
-protected:
+public:
 	virtual ~IScene() {}
 };
 


### PR DESCRIPTION
…cts like std::unique_ptr or std::shared_ptr, it has to have a public destructor.